### PR TITLE
OSC compatibility patch

### DIFF
--- a/freeliner_sketch/Communicator.pde
+++ b/freeliner_sketch/Communicator.pde
@@ -16,30 +16,29 @@ import websockets.*;
  */
 class FreelinerCommunicator implements FreelinerConfig {
 
-    CommandProcessor commandProcessor;
-    PApplet applet;
+  CommandProcessor commandProcessor;
+  PApplet applet;
 
-    public FreelinerCommunicator(PApplet _pa, CommandProcessor _cp) {
-        commandProcessor = _cp;
-        applet = _pa;
-    }
+  public FreelinerCommunicator(PApplet _pa, CommandProcessor _cp) {
+    commandProcessor = _cp;
+    applet = _pa;
+  }
 
-    /**
-    * Pass commands to the command processor
-    * @param String cmd
-    */
-    public void receive(String _cmd) {
-        commandProcessor.queueCMD(_cmd);
-    }
+  /**
+   * Pass commands to the command processor
+   * @param String cmd
+   */
+  public void receive(String _cmd) {
+    commandProcessor.queueCMD(_cmd);
+  }
 
-    /**
-    * Send info to the communicating end.
-    * @param String stuff
-    */
-    public void send(String _s) {
-        println("Sending : "+_s);
-    }
-
+  /**
+   * Send info to the communicating end.
+   * @param String stuff
+   */
+  public void send(String _s) {
+    println("Sending : "+_s);
+  }
 }
 
 
@@ -48,85 +47,102 @@ class FreelinerCommunicator implements FreelinerConfig {
  * OSC communicator, send and receive messages with freeliner!
  */
 class OSCCommunicator extends FreelinerCommunicator implements OscEventListener {
-    // network
-    OscP5 oscP5;
-    NetAddress toPDpatch;
-    OscMessage tickmsg = new OscMessage("/freeliner/tick");
+  // network
+  OscP5 oscP5;
+  NetAddress toPDpatch;
+  OscMessage tickmsg = new OscMessage("/freeliner/tick");
 
-    public OSCCommunicator(PApplet _pa, CommandProcessor _cp) {
-        super(_pa, _cp);
-        // oscP5 = new OscP5(applet, OSC_IN_PORT);
-        // toPDpatch = new NetAddress(OSC_OUT_IP, OSC_OUT_PORT);
-        // oscP5.addListener(this);
-    }
+  public OSCCommunicator(PApplet _pa, CommandProcessor _cp) {
+    super(_pa, _cp);
+    // oscP5 = new OscP5(applet, OSC_IN_PORT);
+    // toPDpatch = new NetAddress(OSC_OUT_IP, OSC_OUT_PORT);
+    // oscP5.addListener(this);
+  }
 
-    public void send(String _cmd) {
-        String _adr = "/"+_cmd.replaceAll(" ", "/");
-        oscP5.send(new OscMessage(_adr), toPDpatch);
-    }
+  public void send(String _cmd) {
+    String _adr = "/"+_cmd.replaceAll(" ", "/");
+    oscP5.send(new OscMessage(_adr), toPDpatch);
+  }
 
-    // oscMessage callback
-    public void oscStatus(OscStatus theStatus) {
-    }
+  // oscMessage callback
+  public void oscStatus(OscStatus theStatus) {
+  }
 
-    public void setSyncAddress(String _ip, int _port) {
-        toPDpatch = new NetAddress(_ip, _port);
-    }
+  public void setSyncAddress(String _ip, int _port) {
+    toPDpatch = new NetAddress(_ip, _port);
+  }
 
-    void oscEvent(OscMessage _mess) {
-        String _cmd = _mess.addrPattern().replaceAll("/", " ").replaceFirst(" ", "");
-        receive(_cmd);
+  void oscEvent(OscMessage _mess) {
+    String _cmd = "";
+    // check if it's a proper osc message. if it has a typetag, it is.
+    // in that case, the value will be the last part of the command
+    if (_mess.checkTypetag("f")) {
+      _cmd = _mess.addrPattern().replaceAll("/", " ").replaceFirst(" ", "");
+      _cmd = _cmd + " " + _mess.get(0).floatValue();
+    } else if (_mess.checkTypetag("i")) {
+      _cmd = _mess.addrPattern().replaceAll("/", " ").replaceFirst(" ", "");
+      _cmd = _cmd + " " + _mess.get(0).intValue();
+    } else if (_mess.checkTypetag("s")) {
+      _cmd = _mess.addrPattern().replaceAll("/", " ").replaceFirst(" ", "");
+      _cmd = _cmd + " " + _mess.get(0).stringValue();
+      // otherwise, it's a proprietary freeliner osc message.
+      // hence, there is no value and the addrPattern is the whole command
+    } else if (_mess.checkTypetag("")) {
+      _cmd = _mess.addrPattern().replaceAll("/", " ").replaceFirst(" ", "");
     }
+    // proceed to process the command
+    receive(_cmd);
+  }
 }
 
-class UDPOSCCommunicator extends OSCCommunicator{
-    public UDPOSCCommunicator(PApplet _pa, CommandProcessor _cp) {
-        super(_pa, _cp);
-        oscP5 = new OscP5(applet, OSC_IN_PORT);
-        toPDpatch = new NetAddress(OSC_OUT_IP, OSC_OUT_PORT);
-        oscP5.addListener(this);
-    }
+
+class UDPOSCCommunicator extends OSCCommunicator {
+  public UDPOSCCommunicator(PApplet _pa, CommandProcessor _cp) {
+    super(_pa, _cp);
+    oscP5 = new OscP5(applet, OSC_IN_PORT);
+    toPDpatch = new NetAddress(OSC_OUT_IP, OSC_OUT_PORT);
+    oscP5.addListener(this);
+  }
 }
 
 
-class TCPOSCCommunicator extends OSCCommunicator{
-    OscP5 oscP5tcpClient;
-    public TCPOSCCommunicator(PApplet _pa, CommandProcessor _cp){
-        super(_pa, _cp);
-        oscP5 = new OscP5(applet, OSC_IN_PORT, OscP5.TCP);
-        // toPDpatch = new NetAddress(OSC_OUT_IP, OSC_OUT_PORT);
-        oscP5tcpClient = new OscP5(applet, OSC_OUT_IP, OSC_OUT_PORT, OscP5.TCP);
-        oscP5.addListener(this);
-    }
+class TCPOSCCommunicator extends OSCCommunicator {
+  OscP5 oscP5tcpClient;
+  public TCPOSCCommunicator(PApplet _pa, CommandProcessor _cp) {
+    super(_pa, _cp);
+    oscP5 = new OscP5(applet, OSC_IN_PORT, OscP5.TCP);
+    // toPDpatch = new NetAddress(OSC_OUT_IP, OSC_OUT_PORT);
+    oscP5tcpClient = new OscP5(applet, OSC_OUT_IP, OSC_OUT_PORT, OscP5.TCP);
+    oscP5.addListener(this);
+  }
 
-    public void setSyncAddress(String _ip, int _port) {
-        oscP5tcpClient = new OscP5(applet, _ip, _port, OscP5.TCP);
-
-    }
-    public void send(String _cmd) {
-        String _adr = "/"+_cmd.replaceAll(" ", "/");
-        oscP5tcpClient.send(new OscMessage(_adr));
-    }
+  public void setSyncAddress(String _ip, int _port) {
+    oscP5tcpClient = new OscP5(applet, _ip, _port, OscP5.TCP);
+  }
+  public void send(String _cmd) {
+    String _adr = "/"+_cmd.replaceAll(" ", "/");
+    oscP5tcpClient.send(new OscMessage(_adr));
+  }
 }
 
 /**
  * WebSocket for browser based gui!!
  */
 class WebSocketCommunicator extends FreelinerCommunicator {
-    WebsocketServer webSock;
+  WebsocketServer webSock;
 
-    public WebSocketCommunicator(PApplet _pa, CommandProcessor _cp) {
-        super(_pa, _cp);
-        webSock = new WebsocketServer(applet, WEBSOCKET_PORT,"/freeliner");
-        //webSock.setNewCallback(this);
-    }
+  public WebSocketCommunicator(PApplet _pa, CommandProcessor _cp) {
+    super(_pa, _cp);
+    webSock = new WebsocketServer(applet, WEBSOCKET_PORT, "/freeliner");
+    //webSock.setNewCallback(this);
+  }
 
-    public void send(String _s) {
-        webSock.sendMessage(_s);
-    }
+  public void send(String _s) {
+    webSock.sendMessage(_s);
+  }
 
-    public void webSocketServerEvent(String _cmd) {
-        // it
-        receive(_cmd);
-    }
+  public void webSocketServerEvent(String _cmd) {
+    // it
+    receive(_cmd);
+  }
 }

--- a/freeliner_sketch/data/doc/autodoc.md
+++ b/freeliner_sketch/data/doc/autodoc.md
@@ -1,4 +1,4 @@
-Generated on 2018/12/12 with freeliner version 0.4.7
+Generated on 2018/12/13 with freeliner version 0.4.7
 ### keys ###
 | key | parameter | type | description | cmd |
 |:---:|---|---|---|---|

--- a/freeliner_sketch/freeliner_sketch.pde
+++ b/freeliner_sketch/freeliner_sketch.pde
@@ -13,7 +13,9 @@ import netP5.*;
 /**
  * HELLO THERE! WELCOME to FREELINER
  * There is a bunch of settings in the Config.pde file.
- */
+ * 
+ * webGUI: http://localhost:8000/index.html
+ **/
 
 // for loading configuration
 // false -> use following parameters


### PR DESCRIPTION
Should now also accept regular OSC messages. These need to have the last part of the command as value, for example:

/tr/A

Where /tr/ is the addressPattern and A is a string.